### PR TITLE
FIX error: Failed to fetch http://deb.debian.org/debian/dists/jessie-…

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,5 +1,7 @@
 FROM grafana/grafana:4.4.2
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y curl gettext-base && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /etc/grafana


### PR DESCRIPTION


Fixes the error:
```
Fetched 10.1 MB in 6s (1576 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
ERROR: Service 'grafana' failed to build: The command '/bin/sh -c apt-get update && apt-get install -y curl gettext-base && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100

```

To reproduce: 
- delete relevant containers and images
- then run `docker-compose up`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bushnevyuri/dockergrafanainfluxkit/8)
<!-- Reviewable:end -->
